### PR TITLE
Send Authorization header preemptively with each HTTP request

### DIFF
--- a/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
+++ b/src/main/java/org/killbill/billing/client/KillBillHttpClient.java
@@ -531,7 +531,7 @@ public class KillBillHttpClient {
         }
 
         if (username != null && password != null) {
-            final Realm realm = new RealmBuilder().setPrincipal(username).setPassword(password).build();
+            final Realm realm = new RealmBuilder().setPrincipal(username).setPassword(password).setScheme(Realm.AuthScheme.BASIC).setUsePreemptiveAuth(true).build();
             builder.setRealm(realm);
         }
 


### PR DESCRIPTION
When the Kill Bill HTTP client sends a request to Kill Bill, it initially omits the Authorization header. If Kill Bill is configured to require authentication, it will send back a response with status code 401. The client then re-sends the request, this time with the necessary `Authorization` header.

As far as I can tell, there's no good reason to require two HTTP exchanges for every request. It adds unnecessary traffic to the network, costs additional time and computing resources, and creates noise in the logs when DEBUG level logging is turned on.

This change causes the Kill Bill HTTP client to send the `Authorization` header preemptively with each request. It allows Kill Bill to service the request without requesting authentication from the client.
